### PR TITLE
Enable static build for Cygwin (MSYS, MinGW)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ else ifneq (, $(shell echo $(UNAME_S) | grep -E 'MSYS|MINGW|CYGWIN'))
     SHARED_EXT = dll
     TARGET = $(BASE_NAME).$(SHARED_EXT)
     TARGET_ONLY = YES
-    NO_STATIC = 1
     LDFLAGS += -Wl,--out-implib,$(TARGET).a
 else
     SHARED_EXT = so


### PR DESCRIPTION
I'm working on complete Windows-only uTox build with all its dependencies (via Cygwin).

This change is needed to be able to build `filter_audio` statically on Cygwin.